### PR TITLE
include generated lib directory artifacts

### DIFF
--- a/.github/workflows/create_js_branch.yaml
+++ b/.github/workflows/create_js_branch.yaml
@@ -40,6 +40,11 @@ jobs:
       - name: build
         run: npm run build
 
+      - name: Remove lib from gitignore
+        continue-on-error: true
+        run: |
+          sed -i '/lib/d' ./.gitignore
+
       - name: create branch
         run: |
           git checkout -b ${BRANCH}

--- a/.github/workflows/create_js_branch.yaml
+++ b/.github/workflows/create_js_branch.yaml
@@ -40,12 +40,10 @@ jobs:
       - name: build
         run: npm run build
 
-      - name: Remove lib from gitignore
-        continue-on-error: true
-        run: |
-          sed -i '/lib/d' ./.gitignore
-
       - name: create branch
         run: |
           git checkout -b ${BRANCH}
+          sed -i '/lib/d' ./.gitignore
+          git add .
+          git commit -m "build"
           git push origin ${BRANCH}

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -37,5 +37,5 @@ jobs:
           name: ${{ inputs.version }}
           tag: ${{ inputs.version }}
           body: ${{ inputs.body }}
-          commit: ${{ github.ref }}
+          commit: refs/heads/${{ inputs.branch }}
           prerelease: ${{ inputs.prerelease == 'prereleased' }}

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -39,6 +39,6 @@ jobs:
     if: needs.checkVersion.outputs.exists == 'false'
     uses: ./.github/workflows/create_release.yaml
     with:
-      branch: release/${{ needs.extractChangelog.outputs.version }}
+      branch: releases/${{ needs.extractChangelog.outputs.version }}
       version: ${{ needs.extractChangelog.outputs.version }}
       body: ${{ needs.extractChangelog.outputs.body }}

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -33,7 +33,7 @@ jobs:
     with:
         version: ${{ needs.extractChangelog.outputs.version }}
   createRelease:
-    needs: [checkVersion, extractChangelog]
+    needs: [checkVersion, extractChangelog, createBranch]
     permissions:
       contents: write
     if: needs.checkVersion.outputs.exists == 'false'

--- a/.github/workflows/switch_js_branch.yaml
+++ b/.github/workflows/switch_js_branch.yaml
@@ -42,9 +42,14 @@ jobs:
               git rm -r node_modules --ignore-unmatch
               git merge tmp
               git branch -D tmp
-              git push origin ${BRANCH}
             else
               git checkout -b ${BRANCH}
-              git push origin ${BRANCH}
             fi
-            
+      - name: Remove lib from gitignore
+        continue-on-error: true
+        run: |
+          sed -i '/lib/d' ./.gitignore
+
+      - name: Push to branch
+        run: |
+          git push origin ${BRANCH}


### PR DESCRIPTION
restructure the workflow to first build and push the generated artifacts in the lib directory, and then generate a release using that head ref from the new branch

add sed delete step to remove the lib directory from the .gitignore