### PR TITLE
add v prefix to release, branch, and tag

### DIFF
--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -33,7 +33,7 @@ jobs:
     with:
         version: v${{ needs.extractChangelog.outputs.version }}
   createRelease:
-    needs: [checkVersion, extractChangelog]
+    needs: [checkVersion, extractChangelog, createBranch]
     permissions:
       contents: write
     if: needs.checkVersion.outputs.exists == 'false'

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: mukunku/tag-exists-action@5dfe2bf779fe5259360bb10b2041676713dcc8a3 # v1.1.0
         id: tag-exists
         with:
-          tag: ${{ needs.extractChangelog.outputs.version }}
+          tag: v${{ needs.extractChangelog.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   createBranch:
@@ -31,14 +31,14 @@ jobs:
     if: needs.checkVersion.outputs.exists == 'false'
     uses: ./.github/workflows/create_js_branch.yaml
     with:
-        version: ${{ needs.extractChangelog.outputs.version }}
+        version: v${{ needs.extractChangelog.outputs.version }}
   createRelease:
-    needs: [checkVersion, extractChangelog, createBranch]
+    needs: [checkVersion, extractChangelog]
     permissions:
       contents: write
     if: needs.checkVersion.outputs.exists == 'false'
     uses: ./.github/workflows/create_release.yaml
     with:
-      branch: releases/${{ needs.extractChangelog.outputs.version }}
-      version: ${{ needs.extractChangelog.outputs.version }}
+      branch: release/v${{ needs.extractChangelog.outputs.version }}
+      version: v${{ needs.extractChangelog.outputs.version }}
       body: ${{ needs.extractChangelog.outputs.body }}

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -39,6 +39,6 @@ jobs:
     if: needs.checkVersion.outputs.exists == 'false'
     uses: ./.github/workflows/create_release.yaml
     with:
-      branch: release/v${{ needs.extractChangelog.outputs.version }}
+      branch: releases/v${{ needs.extractChangelog.outputs.version }}
       version: v${{ needs.extractChangelog.outputs.version }}
       body: ${{ needs.extractChangelog.outputs.body }}


### PR DESCRIPTION
add the v prefix to our generated releases to allow the GitHub Marketplace to detect the generated releases

this should resolve https://github.com/Azure/k8s-deploy/issues/300

The changes were tested with the following in a fork, yielding the correct prefix behavior in all three desired places:
[Test Release Changelog Entry](https://github.com/davidgamero/k8s-deploy/commit/467df06f753278b3fe21ceba966512306f46099c) that kicks off run (should have no prefix to follow the [keep a changelog standard](https://keepachangelog.com/en/1.0.0/))

[Generated Release with prefix](https://github.com/davidgamero/k8s-deploy/releases/tag/v4.16.0)
[Generated Tag with prefix](https://github.com/davidgamero/k8s-deploy/tree/v4.16.0)
[Created Branch with prefix](https://github.com/davidgamero/k8s-deploy/tree/releases/v4.16.0)

[Action run with logs](https://github.com/davidgamero/k8s-deploy/actions/runs/7039451381)