### PR TITLE
Add major version tags that update on minor/patch releases

### DIFF
--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -72,4 +72,4 @@ jobs:
            git config user.name 'github-actions[bot]'
            git config user.email 'github-actions[bot]@users.noreply.github.com'
            git tag -a $MAJOR_VERSION_TAG  -m "Latest $MAJOR_VERSION_TAG Release"
-           git push origin regs/tags/$MAJOR_VERSION_TAG
+           git push origin refs/tags/$MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -70,4 +70,6 @@ jobs:
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run: |
            git tag -a $MAJOR_VERSION_TAG  -m "Latest $MAJOR_VERSION_TAG Release"
+           git config user.name 'github-actions[bot]'
+           git config user.email 'github-actions[bot]@users.noreply.github.com'
            git push origin regs/tags/$MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -67,4 +67,4 @@ jobs:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
-           gh release create $MAJOR_VERSION_TAG
+           gh release create $MAJOR_VERSION_TAG --target releases/v${{ needs.extractChangelog.outputs.version }}

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -61,10 +61,12 @@ jobs:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
-           gh release delete --cleanup-tag -y $MAJOR_VERSION_TAG
+           git push origin :refs/tags/$MAJOR_VERSION_TAG
        - name: create new major tag
          env:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
-           gh release create $MAJOR_VERSION_TAG --target releases/v${{ needs.extractChangelog.outputs.version }} -n "Latest $MAJOR_VERSION_TAG Release"
+           git checkout releases/v${{ needs.extractChangelog.outputs.version }}
+           git tag -a $MAJOR_VERSION_TAG  -m "Latest $MAJOR_VERSION_TAG Release"
+           git push origin regs/tags/$MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -68,6 +68,6 @@ jobs:
          env:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
-         run:
+         run: |
            git tag -a $MAJOR_VERSION_TAG  -m "Latest $MAJOR_VERSION_TAG Release"
            git push origin regs/tags/$MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -54,7 +54,7 @@ jobs:
          env:
            NEW_RELEASE_TAG: ${{ needs.extractChangelog.outputs.version }}
          run:
-           echo "MAJOR_VERSION_TAG=${NEW_RELEASE_TAG%%.*}" >> "$GITHUB_OUTPUT"
+           echo "MAJOR_VERSION_TAG=v${NEW_RELEASE_TAG%%.*}" >> "$GITHUB_OUTPUT"
        - name: delete old major tag
          continue-on-error: true
          env:
@@ -67,4 +67,4 @@ jobs:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
-           gh release create v$MAJOR_VERSION_TAG
+           gh release create $MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -67,4 +67,4 @@ jobs:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
-           gh release create MAJOR_VERSION_TAG
+           gh release create v$MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -42,3 +42,26 @@ jobs:
       branch: releases/v${{ needs.extractChangelog.outputs.version }}
       version: v${{ needs.extractChangelog.outputs.version }}
       body: ${{ needs.extractChangelog.outputs.body }}
+  updateMajorTag:
+     runs-on: ubuntu-latest
+     permissions:
+       contents: write
+     needs: [extractChangelog, createRelease]
+     steps:
+       - name: get major version tag
+         id: major-version-tag
+         env:
+           NEW_RELEASE_TAG: ${{ needs.extractChangelog.outputs.version }}
+         run:
+           echo "MAJOR_VERSION_TAG=${NEW_RELEASE_TAG%%.*}" >> "$GITHUB_OUTPUT"
+       - name: delete old major tag
+         continue-on-error: true
+         env:
+            MAJOR_VERSION_TAG: steps.major-version-tag.outputs.MAJOR_VERSION_TAG
+         run:
+           gh release delete --cleanup-tag -y MAJOR_VERSION_TAG
+       - name: create new major tag
+         env:
+            MAJOR_VERSION_TAG: steps.major-version-tag.outputs.MAJOR_VERSION_TAG
+         run:
+           gh release create MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -57,11 +57,13 @@ jobs:
        - name: delete old major tag
          continue-on-error: true
          env:
+            GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: steps.major-version-tag.outputs.MAJOR_VERSION_TAG
          run:
            gh release delete --cleanup-tag -y MAJOR_VERSION_TAG
        - name: create new major tag
          env:
+            GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: steps.major-version-tag.outputs.MAJOR_VERSION_TAG
          run:
            gh release create MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -48,6 +48,7 @@ jobs:
        contents: write
      needs: [extractChangelog, createRelease]
      steps:
+       - uses: actions/checkout@v4
        - name: get major version tag
          id: major-version-tag
          env:
@@ -58,12 +59,12 @@ jobs:
          continue-on-error: true
          env:
             GH_TOKEN: ${{ github.token }}
-            MAJOR_VERSION_TAG: steps.major-version-tag.outputs.MAJOR_VERSION_TAG
+            MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
            gh release delete --cleanup-tag -y MAJOR_VERSION_TAG
        - name: create new major tag
          env:
             GH_TOKEN: ${{ github.token }}
-            MAJOR_VERSION_TAG: steps.major-version-tag.outputs.MAJOR_VERSION_TAG
+            MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
            gh release create MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -49,6 +49,8 @@ jobs:
      needs: [extractChangelog, createRelease]
      steps:
        - uses: actions/checkout@v4
+         with:
+           ref: releases/v${{ needs.extractChangelog.outputs.version }}
        - name: get major version tag
          id: major-version-tag
          env:
@@ -67,6 +69,5 @@ jobs:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
-           git checkout releases/v${{ needs.extractChangelog.outputs.version }}
            git tag -a $MAJOR_VERSION_TAG  -m "Latest $MAJOR_VERSION_TAG Release"
            git push origin regs/tags/$MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -67,4 +67,4 @@ jobs:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
-           gh release create $MAJOR_VERSION_TAG --target releases/v${{ needs.extractChangelog.outputs.version }}
+           gh release create $MAJOR_VERSION_TAG --target releases/v${{ needs.extractChangelog.outputs.version }} -n "Latest $MAJOR_VERSION_TAG Release"

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -46,7 +46,7 @@ jobs:
      runs-on: ubuntu-latest
      permissions:
        contents: write
-     needs: [extractChangelog, createRelease]
+     needs: [extractChangelog, createBranch, createRelease]
      steps:
        - uses: actions/checkout@v4
          with:

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -69,7 +69,7 @@ jobs:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run: |
-           git tag -a $MAJOR_VERSION_TAG  -m "Latest $MAJOR_VERSION_TAG Release"
            git config user.name 'github-actions[bot]'
            git config user.email 'github-actions[bot]@users.noreply.github.com'
+           git tag -a $MAJOR_VERSION_TAG  -m "Latest $MAJOR_VERSION_TAG Release"
            git push origin regs/tags/$MAJOR_VERSION_TAG

--- a/.github/workflows/release_js_project.yaml
+++ b/.github/workflows/release_js_project.yaml
@@ -61,7 +61,7 @@ jobs:
             GH_TOKEN: ${{ github.token }}
             MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
          run:
-           gh release delete --cleanup-tag -y MAJOR_VERSION_TAG
+           gh release delete --cleanup-tag -y $MAJOR_VERSION_TAG
        - name: create new major tag
          env:
             GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
add support for major version tags that are updated (deleted and re-created) on minor and patch versions.

community support for these was overwhelming, so this PR adds them to our release workflow to centralize support for this workflow.

tested on my fork of setup-helm action [here](https://github.com/davidgamero/setup-helm/releases/tag/v4) with tag deletion and re-creation succeeding 