### PR TITLE
remove no bin links install

### DIFF
--- a/.github/workflows/create_js_branch.yaml
+++ b/.github/workflows/create_js_branch.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          npm install --no-bin-links
+          npm install
 
       - name: build
         run: npm run build

--- a/.github/workflows/switch_js_branch.yaml
+++ b/.github/workflows/switch_js_branch.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          npm install --no-bin-links
+          npm install
 
       - name: build
         run: npm run build


### PR DESCRIPTION
the release workflow is failing to bundle for Azure/setup-kubectl, where the --no-bin-links flag is breaking vercel/ncc build bundling.

integration tests bundle the same way, but don't use the `--no-bin-links`

updating integration tests to delete the `node_modules` directory continues to pass, indicating that the bundled index.js output from ncc on https://github.com/Azure/setup-kubectl/pull/168

this supports that the --no-bin-links flag is no longer necessary for successful builds on github actions with verce/ncc



```
npm install
npm run build
# remove node_modules to match production environment where only index.js is present
 rm -rf node_modules 
```

validated against a test release on my fork of setup-kubectl and this repo https://github.com/davidgamero/setup-kubectl/releases/tag/v9.99.99