### PR TITLE
Monthly release workflow

### DIFF
--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -1,0 +1,15 @@
+{
+   "categories": [
+      {
+         "title": "### Changed",
+         "labels": []
+      }
+   ],
+   "template": "#{{CHANGELOG}}",
+   "pr_template": "- ##{{NUMBER}} #{{TITLE}}",
+   "empty_template": "### Changed\n\n- No changes since last release",
+   "sort": {
+      "order": "ASC",
+      "on_property": "mergedAt"
+   }
+}

--- a/.github/workflows/monthly_release.yaml
+++ b/.github/workflows/monthly_release.yaml
@@ -1,147 +1,224 @@
 name: Monthly Auto Release
 
 on:
-  workflow_call: {}
+   workflow_call: {}
+
+concurrency:
+   group: auto-release
+   cancel-in-progress: false
 
 jobs:
-  version-check:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      latest_version: ${{ steps.latest.outputs.latest }}
-      new_version: ${{ steps.bump.outputs.new_version }}
+   prepare-release:
+      name: Prepare Release
+      runs-on: ubuntu-latest
+      permissions:
+         contents: read
+      outputs:
+         new_version: ${{ steps.bump.outputs.new_version }}
+         changelog: ${{ steps.changelog.outputs.changelog }}
+         latest_tag: ${{ steps.get_tag.outputs.latest_tag }}
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      steps:
+         - name: Checkout code
+           uses: actions/checkout@v4
+           with:
+              fetch-depth: 0
 
-      - name: Get latest tag
-        id: latest
-        run: |
-          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          echo "latest=$latest_tag" >> $GITHUB_OUTPUT
+         - name: Set up Node.js
+           uses: actions/setup-node@v4
+           with:
+              node-version: '20'
 
-      - name: Bump patch version
-        id: bump
-        run: |
-          version="${{ steps.latest.outputs.latest }}"
-          IFS='.' read -r major minor patch <<<"${version#v}"
-          patch=$((patch + 1))
-          new_version="v$major.$minor.$patch"
-          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+         - name: Get latest tag
+           id: get_tag
+           run: |
+              latest=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
+                       | sort -V | tail -n1)
+              LATEST_TAG=${latest:-v0.0.0}
+              echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+              echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
 
-  changelog-generation:
-    runs-on: ubuntu-latest
-    needs: version-check
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      changelog_body: ${{ steps.changelog.outputs.body }}
+         - name: Bump patch version
+           id: bump
+           run: |
+              # bump package.json & lockfile without tagging
+              npm version patch --no-git-tag-version
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+              # capture and expose the new version (with leading 'v')
+              NEW_VERSION="v$(node -p "require('./package.json').version")"
+              echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Generate changelog from merged PRs
-        id: changelog
-        run: |
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          gh pr list --state merged --json title,number,mergedAt \
-            --jq '.[] | "- \(.title) (#\(.number))"' >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         - name: Build changelog from merged PRs
+           id: changelog
+           uses: mikepenz/release-changelog-builder-action@v4
+           with:
+              configuration: .github/changelog-config.json
+              fromTag: ${{ steps.get_tag.outputs.latest_tag }}
+              toTag: HEAD
+           env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  update-changelog:
-    runs-on: ubuntu-latest
-    needs: [version-check, changelog-generation]
-    permissions:
-      contents: write
+   checkVersion:
+      name: Check if Version Exists
+      needs: prepare-release
+      runs-on: ubuntu-latest
+      permissions:
+         contents: read
+      outputs:
+         exists: ${{ steps.tag-exists.outputs.exists }}
+      steps:
+         - name: Check if tag exists
+           uses: mukunku/tag-exists-action@bdad1eaa119ce71b150b952c97351c75025c06a9 # v1.6.0
+           id: tag-exists
+           with:
+              tag: ${{ needs.prepare-release.outputs.new_version }}
+           env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+   commit-release:
+      name: Commit Release Changes
+      runs-on: ubuntu-latest
+      needs: [prepare-release, checkVersion]
+      if: needs.checkVersion.outputs.exists == 'false'
+      permissions:
+         contents: write
 
-      - name: Update CHANGELOG.md if it exists
-        run: |
-          if [[ -f CHANGELOG.md ]]; then
-            echo "Updating CHANGELOG.md"
-            DATE=$(date +'%Y-%m-%d')
-            VERSION="${{ needs.version-check.outputs.new_version }}"
-            echo -e "## $VERSION - $DATE\n\n${{ needs.changelog-generation.outputs.changelog_body }}\n" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+      steps:
+         - name: Checkout code
+           uses: actions/checkout@v4
+           with:
+              fetch-depth: 0
 
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add CHANGELOG.md
-            git commit -m "docs: update changelog for $VERSION"
-            git push origin HEAD
-          else
-            echo "No CHANGELOG.md file found. Skipping update."
-          fi
+         - name: Set up Node.js
+           uses: actions/setup-node@v4
+           with:
+              node-version: '20'
 
-  create-tag:
-    runs-on: ubuntu-latest
-    needs: [version-check, update-changelog]
-    permissions:
-      contents: write
+         - name: Apply version bump and update files
+           env:
+              NEW_VERSION: ${{ needs.prepare-release.outputs.new_version }}
+              CHANGELOG_BODY: ${{ needs.prepare-release.outputs.changelog }}
+           run: |
+              # Apply the version bump
+              npm version $NEW_VERSION --no-git-tag-version
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+              # Update CHANGELOG.md if present
+              if [[ -f CHANGELOG.md ]]; then
+                DATE=$(date +'%Y-%m-%d')
+                ENTRY="## [${NEW_VERSION#v}] - $DATE"$'\n\n'"${CHANGELOG_BODY%$'\n'}"
 
-      - name: Pull latest changes
-        run: git pull origin ${{ github.ref_name }}
+                # Insert right under "# Changelog"
+                awk -v e="$ENTRY" '
+                  /^# Changelog/ {
+                    print
+                    print ""
+                    printf e
+                    next
+                  }
+                  { print }
+                ' CHANGELOG.md > tmp && mv tmp CHANGELOG.md
+                echo "Updated CHANGELOG.md"
+              else
+                echo "No CHANGELOG.md—skipping."
+              fi
 
-      - name: Create and push version tag
-        run: |
-          git tag ${{ needs.version-check.outputs.new_version }}
-          git push origin ${{ needs.version-check.outputs.new_version }}
+         - name: Commit and push changes
+           run: |
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
 
-  create-release:
-    runs-on: ubuntu-latest
-    needs: [version-check, changelog-generation, create-tag]
-    permissions:
-      contents: write
+              # Add all changed files
+              git add .
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+              # Check if there are changes to commit
+              if git diff --staged --quiet; then
+                echo "No changes to commit"
+              else
+                git commit -m "chore: release ${{ needs.prepare-release.outputs.new_version }}"
+                git push origin main
+                echo "Changes committed and pushed"
+              fi
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ needs.version-check.outputs.new_version }}
-          name: "Release ${{ needs.version-check.outputs.new_version }}"
-          body: ${{ needs.changelog-generation.outputs.changelog_body }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+   create-tags:
+      name: Create Release Tags
+      runs-on: ubuntu-latest
+      needs: [prepare-release, checkVersion, commit-release]
+      if: needs.checkVersion.outputs.exists == 'false'
+      permissions:
+         contents: write
 
-  update-major-tag:
-    runs-on: ubuntu-latest
-    needs: [version-check, create-release]
-    permissions:
-      contents: write
+      steps:
+         - name: Checkout main branch
+           uses: actions/checkout@v4
+           with:
+              ref: main
+              fetch-depth: 0
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+         - name: Create and push version tag
+           run: |
+              NEW_VERSION="${{ needs.prepare-release.outputs.new_version }}"
 
-      - name: Update major version tag
-        run: |
-          version=${{ needs.version-check.outputs.new_version }}
-          major_tag="v${version#v}"
-          major_tag="v${major_tag%%.*}"
+              # Create and push the full version tag
+              git tag "$NEW_VERSION"
+              git push origin "$NEW_VERSION"
 
-          git push origin :refs/tags/$major_tag || true
-          git tag -fa $major_tag -m "Latest $major_tag release"
-          git push origin $major_tag
+   create-release:
+      name: Create GitHub Release
+      runs-on: ubuntu-latest
+      needs: [prepare-release, checkVersion, create-tags]
+      if: needs.checkVersion.outputs.exists == 'false'
+      permissions:
+         contents: write
+
+      steps:
+         - name: Checkout code
+           uses: actions/checkout@v4
+
+         - name: Publish GitHub Release
+           uses: ncipollo/release-action@v1
+           with:
+              tag: ${{ needs.prepare-release.outputs.new_version }}
+              name: ${{ needs.prepare-release.outputs.new_version }}
+              body: ${{ needs.prepare-release.outputs.changelog }}
+           env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+   update-major-tag:
+      name: Update Major Version Tag
+      runs-on: ubuntu-latest
+      needs: [prepare-release, create-release]
+      permissions:
+         contents: write
+
+      steps:
+         - name: Checkout main branch
+           uses: actions/checkout@v4
+           with:
+              ref: main
+              fetch-depth: 0
+
+         - name: Get major version tag
+           id: major-version-tag
+           env:
+              NEW_RELEASE_TAG: ${{ needs.prepare-release.outputs.new_version }}
+           run: |
+              # Extract major version (e.g., v1.2.3 -> v1)
+              echo "MAJOR_VERSION_TAG=${NEW_RELEASE_TAG%%.*}" >> "$GITHUB_OUTPUT"
+
+         - name: Delete old major tag
+           continue-on-error: true
+           env:
+              GH_TOKEN: ${{ github.token }}
+              MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
+           run: |
+              git push origin :refs/tags/$MAJOR_VERSION_TAG
+
+         - name: Create new major tag
+           env:
+              GH_TOKEN: ${{ github.token }}
+              MAJOR_VERSION_TAG: ${{ steps.major-version-tag.outputs.MAJOR_VERSION_TAG }}
+           run: |
+              git config user.name 'github-actions[bot]'
+              git config user.email 'github-actions[bot]@users.noreply.github.com'
+              git tag -a $MAJOR_VERSION_TAG -m "Latest $MAJOR_VERSION_TAG Release"
+              git push origin refs/tags/$MAJOR_VERSION_TAG

--- a/.github/workflows/monthly_release.yaml
+++ b/.github/workflows/monthly_release.yaml
@@ -4,9 +4,12 @@ on:
   workflow_call: {}
 
 jobs:
-  release:
+  version-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
+      latest_version: ${{ steps.latest.outputs.latest }}
       new_version: ${{ steps.bump.outputs.new_version }}
 
     steps:
@@ -30,6 +33,19 @@ jobs:
           new_version="v$major.$minor.$patch"
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
+  changelog-generation:
+    runs-on: ubuntu-latest
+    needs: version-check
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      changelog_body: ${{ steps.changelog.outputs.body }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Generate changelog from merged PRs
         id: changelog
         run: |
@@ -40,13 +56,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  update-changelog:
+    runs-on: ubuntu-latest
+    needs: [version-check, changelog-generation]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Update CHANGELOG.md if it exists
         run: |
           if [[ -f CHANGELOG.md ]]; then
             echo "Updating CHANGELOG.md"
             DATE=$(date +'%Y-%m-%d')
-            VERSION="${{ steps.bump.outputs.new_version }}"
-            echo -e "## $VERSION - $DATE\n\n${{ steps.changelog.outputs.body }}\n" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+            VERSION="${{ needs.version-check.outputs.new_version }}"
+            echo -e "## $VERSION - $DATE\n\n${{ needs.changelog-generation.outputs.changelog_body }}\n" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
 
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -57,23 +85,60 @@ jobs:
             echo "No CHANGELOG.md file found. Skipping update."
           fi
 
+  create-tag:
+    runs-on: ubuntu-latest
+    needs: [version-check, update-changelog]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Pull latest changes
+        run: git pull origin ${{ github.ref_name }}
+
       - name: Create and push version tag
         run: |
-          git tag ${{ steps.bump.outputs.new_version }}
-          git push origin ${{ steps.bump.outputs.new_version }}
+          git tag ${{ needs.version-check.outputs.new_version }}
+          git push origin ${{ needs.version-check.outputs.new_version }}
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [version-check, changelog-generation, create-tag]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.bump.outputs.new_version }}
-          name: "Release ${{ steps.bump.outputs.new_version }}"
-          body: ${{ steps.changelog.outputs.body }}
+          tag_name: ${{ needs.version-check.outputs.new_version }}
+          name: "Release ${{ needs.version-check.outputs.new_version }}"
+          body: ${{ needs.changelog-generation.outputs.changelog_body }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  update-major-tag:
+    runs-on: ubuntu-latest
+    needs: [version-check, create-release]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Update major version tag
         run: |
-          version=${{ steps.bump.outputs.new_version }}
+          version=${{ needs.version-check.outputs.new_version }}
           major_tag="v${version#v}"
           major_tag="v${major_tag%%.*}"
 

--- a/.github/workflows/monthly_release.yaml
+++ b/.github/workflows/monthly_release.yaml
@@ -1,0 +1,82 @@
+name: Monthly Auto Release
+
+on:
+  workflow_call: {}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.bump.outputs.new_version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: latest
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "latest=$latest_tag" >> $GITHUB_OUTPUT
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          version="${{ steps.latest.outputs.latest }}"
+          IFS='.' read -r major minor patch <<<"${version#v}"
+          patch=$((patch + 1))
+          new_version="v$major.$minor.$patch"
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog from merged PRs
+        id: changelog
+        run: |
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          gh pr list --state merged --json title,number,mergedAt \
+            --jq '.[] | "- \(.title) (#\(.number))"' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update CHANGELOG.md if it exists
+        run: |
+          if [[ -f CHANGELOG.md ]]; then
+            echo "Updating CHANGELOG.md"
+            DATE=$(date +'%Y-%m-%d')
+            VERSION="${{ steps.bump.outputs.new_version }}"
+            echo -e "## $VERSION - $DATE\n\n${{ steps.changelog.outputs.body }}\n" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add CHANGELOG.md
+            git commit -m "docs: update changelog for $VERSION"
+            git push origin HEAD
+          else
+            echo "No CHANGELOG.md file found. Skipping update."
+          fi
+
+      - name: Create and push version tag
+        run: |
+          git tag ${{ steps.bump.outputs.new_version }}
+          git push origin ${{ steps.bump.outputs.new_version }}
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.bump.outputs.new_version }}
+          name: "Release ${{ steps.bump.outputs.new_version }}"
+          body: ${{ steps.changelog.outputs.body }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update major version tag
+        run: |
+          version=${{ steps.bump.outputs.new_version }}
+          major_tag="v${version#v}"
+          major_tag="v${major_tag%%.*}"
+
+          git push origin :refs/tags/$major_tag || true
+          git tag -fa $major_tag -m "Latest $major_tag release"
+          git push origin $major_tag


### PR DESCRIPTION
Adds a fully automated monthly release workflow. This will automatically generate and publish versioned releases, primarily to bundle Dependabot dependency updates once per month ensuring our GitHub Actions stay up to date without manual intervention.

This workflow currently commits to the main branch directly, but we might want to create a PR and manually approve it to avoid that. 