### PR TITLE
release: prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Change Log
 
+## [1.1.0] - 2026-07-30
+
+### Added
+
+- #25 Add check-signed-commits reusable workflow
+- #27 Add release-proposal workflow
+- #28 Add CODEOWNERS
+
+### Security
+
+- #35 Bump actions/checkout from 7.0.0 to 7.0.1
+- #34 Bump actions/checkout from 6 to 7 and pin to commit SHA
+- #33 Bump actions/ai-inference from 2.1.0 to 2.1.1
+- #32 Bump mindsers/changelog-reader-action from 2.2.3 to 2.4.0
+- #31 Bump actions/ai-inference from 2.0.7 to 2.1.0
+- #29 Bump actions/ai-inference from 2.0.6 to 2.0.7
+- #24 Bump mukunku/tag-exists-action from 1.6.0 to 1.7.0
+- #22 Bump actions/checkout from 5 to 6
+- #21 Bump ncipollo/release-action from 1.19.1 to 1.20.0
+- #20 Bump ncipollo/release-action from 1.18.0 to 1.19.1
+- #19 Bump actions/checkout from 4 to 5
+- #18 Bump ncipollo/release-action from 1.16.0 to 1.18.0
+
 ## [1.0.3] - 2025-06-20
 - Remove --no-bin-links flag for ncc
 


### PR DESCRIPTION
Minor release since v1.0.3.

**Added** (new reusable workflows → minor bump):
- #25 check-signed-commits reusable workflow
- #27 release-proposal workflow
- #28 CODEOWNERS

**Security / dependency bumps:** #35, #34, #33, #32, #31, #29, #24, #22, #21, #20, #19, #18

Merging this CHANGELOG.md update to main triggers `release.yaml`, which extracts `1.1.0` from the changelog and creates the release + tag (v1 major tag updates to point here).