### PR TITLE
fix(release): correct target_commitish and use v-prefixed tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: mukunku/tag-exists-action@5c39604fe8aef7e65acb6fbcf96ec580f7680313 # v1.7.0
         id: tag-exists
         with:
-          tag: ${{ needs.changelog.outputs.version }}
+          tag: v${{ needs.changelog.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   createRelease:
@@ -33,6 +33,6 @@ jobs:
     if: needs.checkVersion.outputs.exists == 'false'
     uses: ./.github/workflows/create_release.yaml
     with:
-      branch: ${{ github.ref }}
-      version: ${{ needs.changelog.outputs.version }}
+      branch: ${{ github.ref_name }}
+      version: v${{ needs.changelog.outputs.version }}
       body: ${{ needs.changelog.outputs.body }}


### PR DESCRIPTION
## Problem

`release.yaml` fails end-to-end (latest [v1.1.0 run](https://github.com/Azure/action-release-workflows/actions/runs/30658927348)) with:

```
Error 422: Validation Failed: target_commitish is invalid; tag_name is not a valid tag
```

## Cause

`release.yaml` passes the full ref as `branch`, and `create_release.yaml` prepends `refs/heads/` again:

```yaml
branch: ${{ github.ref }}                  # refs/heads/main
commit: refs/heads/${{ inputs.branch }}    # refs/heads/refs/heads/main (invalid)
```

## Fix

In `.github/workflows/release.yaml`:

1. `branch: ${{ github.ref }}` becomes `${{ github.ref_name }}`, giving a valid `refs/heads/main`.
2. Prefix version with `v` in the tag-exists check and release version, producing `v1.1.0` to match the existing `v1.0.x` tags, `release_js_project.yaml`, and the release-proposal `git describe --match 'v*'`. Also repairs the idempotency check that looked for a bare `1.1.0` tag.

## Scope

Affects only this repo's self-release. Consumers use `release_js_project.yaml` and are unaffected.
