### PR TITLE
fix(release): strip refs/heads/ prefix from commit target

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -32,10 +32,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      # release-action's `commit` expects a branch name or SHA, not a fully
+      # qualified ref. Strip a leading refs/heads/ so callers may pass either.
+      - id: normalize
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+        run: echo "commit=${INPUT_BRANCH#refs/heads/}" >> "$GITHUB_OUTPUT"
+
       - uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
         with:
           name: ${{ inputs.version }}
           tag: ${{ inputs.version }}
           body: ${{ inputs.body }}
-          commit: refs/heads/${{ inputs.branch }}
+          commit: ${{ steps.normalize.outputs.commit }}
           prerelease: ${{ inputs.prerelease == 'prereleased' }}


### PR DESCRIPTION
Complements #37.

## What

`create_release.yaml` passes `commit: refs/heads/${{ inputs.branch }}` to `ncipollo/release-action`. That input expects a **branch name or SHA**, not a fully qualified ref. When `release.yaml` calls it with `branch: ${{ github.ref }}` (= `refs/heads/main`), the result is `refs/heads/refs/heads/main` — an invalid `target_commitish` that release-action v1.20.0 rejects with a 422 (seen in the [v1.1.0 run](https://github.com/Azure/action-release-workflows/actions/runs/30658927348)).

This normalizes the input in the reusable workflow by stripping a leading `refs/heads/`, so callers may pass either a full ref or a short branch name.

## Backwards compatibility (all 3 callers)

| Caller | `branch` in | `commit` out |
|---|---|---|
| `release.yaml` | `refs/heads/main` | `main` |
| `release_js_project.yaml` | `releases/vX.Y.Z` | `releases/vX.Y.Z` (unchanged) |
| `nightly_release.yaml` | `releases/nightly` | `releases/nightly` (unchanged) |

Only the `refs/heads/…` form is affected; short branch names pass through untouched. Input is passed via `env` to avoid shell injection.

## Relationship to #37

#37 fixes `release.yaml` at the caller (`github.ref` → `github.ref_name`, plus `v`-prefixed tags). That's still needed and should land. This PR additionally hardens the shared `create_release.yaml` so it never emits a malformed commitish for **any** caller — relevant because the JS repos consume it via the mutable `v1` tag. The two compose cleanly (this PR does not touch `release.yaml`).